### PR TITLE
Update URL for Hack and Tell Berlin

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       <p class="section-description">CHAPTERS</p>
       <ul>
 	<li><a href="http://www.meetup.com/hack-and-tell">NYC</a></li>
-	<li><a href="http://berlinhackandtell.rocks/">Berlin</a></li>
+	<li><a href="http://bhnt.c-base.org/">Berlin</a></li>
 	<li><a href="http://dc.hackandtell.org/">DC</a></li>
 	<li><a href="http://www.meetup.com/London-Hack-and-Tell/">London</a></li>
 	<li><a href="http://www.meetup.com/Toronto-Hack-and-Tell/">Toronto</a></li>


### PR DESCRIPTION
Per ligi, the Berlin chapter has changed their domain name